### PR TITLE
2.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # degit changelog
 
+## 2.9.4
+* Speed up git mode by doing a shallow clone ([#171](https://github.com/Rich-Harris/degit/pull/171))
+
 ## 2.9.3
 * degit --help did not work. It would throw error. Now it reads the help.md like it should. ([#179](https://github.com/Rich-Harris/degit/pull/179))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tiged",
-	"version": "2.9.3",
+	"version": "2.9.4",
 	"engines": {
 		"node": ">=8.0.0"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ class Degit extends EventEmitter {
 	}
 
 	async _cloneWithGit(dir, dest) {
-		await exec(`git clone ${this.repo.ssh} ${dest}`);
+		await exec(`git clone --depth 1 ${this.repo.ssh} ${dest}`);
 		rimrafSync(path.resolve(dest, '.git'));
 	}
 }


### PR DESCRIPTION
Speed up git mode by doing a shallow clone.
Originally this pull request: https://github.com/Rich-Harris/degit/pull/171
I tried to pull it but it wasn't able to fast forward and correct me if I'm wrong but the only option is to rebase and I didn't want to do that. So I just modified and committed the code myself.
Logs:
```
~/projects/tiged >>> gh pr checkout 171 -R Rich-Harris/degit                         
remote: Enumerating objects: 7, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 4 (delta 2), reused 4 (delta 2), pack-reused 0
Unpacking objects: 100% (4/4), 802 bytes | 133.00 KiB/s, done.
From https://github.com/Rich-Harris/degit
 * branch            refs/pull/171/head -> FETCH_HEAD
fatal: Not possible to fast-forward, aborting.
exit status 128
~/projects/tiged >>> 
```