### PR TITLE
add support for privately hosted git repositories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,8 @@ class Degit extends EventEmitter {
 						code: 'DEST_NOT_EMPTY',
 						message: `destination directory is not empty. Using options.force, continuing`
 					});
+
+					rimrafSync(dir);
 				} else {
 					throw new DegitError(
 						`destination directory is not empty, aborting. Use options.force to override`,
@@ -319,7 +321,12 @@ class Degit extends EventEmitter {
 	}
 }
 
-const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
+const supported = {
+	github: '.com',
+	gitlab: '.com',
+	bitbucket: '.com',
+	'git.sr.ht': '.ht',
+};
 
 function parse(src) {
 	const match = /^(?:(?:https:\/\/)?([^:/]+\.[^:/]+)\/|git@([^:/]+)[:/]|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:((?:\/[^/\s#]+)+))?(?:\/)?(?:#(.+))?/.exec(
@@ -331,33 +338,24 @@ function parse(src) {
 		});
 	}
 
-	const site = (match[1] || match[2] || match[3] || 'github').replace(
-		/\.(com|org)$/,
-		''
-	);
-	if (!supported.has(site)) {
-		throw new DegitError(
-			`degit supports GitHub, GitLab, Sourcehut and BitBucket`,
-			{
-				code: 'UNSUPPORTED_HOST'
-			}
-		);
-	}
+	const site = match[1] || match[2] || match[3] || 'github.com';
+	const tldMatch = /\.([a-z]{2,})$/.exec(site)
+	const tld = tldMatch ? tldMatch[0] : null;
+	const siteName = tld ? site.replace(tld, '') : site;
 
 	const user = match[4];
 	const name = match[5].replace(/\.git$/, '');
 	const subdir = match[6];
 	const ref = match[7] || 'HEAD';
 
-	const domain = `${site}.${
-		site === 'bitbucket' ? 'org' : site === 'git.sr.ht' ? '' : 'com'
-	}`;
+	const domain = `${siteName}${tld || supported[siteName] || supported[site] || ''}`
+
 	const url = `https://${domain}/${user}/${name}`;
 	const ssh = `git@${domain}:${user}/${name}`;
 
-	const mode = supported.has(site) ? 'tar' : 'git';
+	const mode = supported[siteName] || supported[site] ? 'tar' : 'git';
 
-	return { site, user, name, ref, url, ssh, subdir, mode };
+	return { site: siteName, user, name, ref, url, ssh, subdir, mode };
 }
 
 async function untar(file, dest, subdir = null) {


### PR DESCRIPTION
- This removes the exception about unsupported sites
- Any git repository hosted anywhere can be used
- Remove existing directory before clone when ran with --force