### PR TITLE
feat: gitea support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -333,7 +333,7 @@ class Degit extends EventEmitter {
 			const tempDir = path.join(dest, '.tiged');
 			if (this.repo.ref && this.repo.ref !== 'HEAD' && !isWin) {
 				await exec(
-					`cd ${tempDir}; git init; git remote add origin ${this.repo.url}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
+					`cd ${tempDir}; git init; git remote add origin ${this.repo.ssh}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
 				);
 			} else {
 				await exec(`git clone --depth 1 ${this.repo.ssh} ${tempDir}`);
@@ -350,7 +350,7 @@ class Degit extends EventEmitter {
 			if (this.repo.ref && this.repo.ref !== 'HEAD' && !isWin) {
 				await fs.mkdir(dest, { recursive: true });
 				await exec(
-					`cd ${dest}; git init; git remote add origin ${this.repo.url}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
+					`cd ${dest}; git init; git remote add origin ${this.repo.ssh}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
 				);
 			} else {
 				await exec(`git clone --depth 1 ${this.repo.ssh} ${dest}`);


### PR DESCRIPTION
Hello,
here is a quickwin to support gitea.

Gitea archives works same way as github archives, same url pattern, and it's the default behavior for tiged, so it's allready supporting gitea but it didn't knew it.

It's difficult to add test because the only official instance of gitea is an ephemeral demo one, but you can test it easily trying any to retrieve an archive using same pattern as the one implemented for github.