### PR TITLE
fix: ssh in mode git

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -333,7 +333,7 @@ class Degit extends EventEmitter {
 			const tempDir = path.join(dest, '.tiged');
 			if (this.repo.ref && this.repo.ref !== 'HEAD' && !isWin) {
 				await exec(
-					`cd ${tempDir}; git init; git remote add origin ${this.repo.url}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
+					`cd ${tempDir}; git init; git remote add origin ${this.repo.ssh}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
 				);
 			} else {
 				await exec(`git clone --depth 1 ${this.repo.ssh} ${tempDir}`);
@@ -350,7 +350,7 @@ class Degit extends EventEmitter {
 			if (this.repo.ref && this.repo.ref !== 'HEAD' && !isWin) {
 				await fs.mkdir(dest, { recursive: true });
 				await exec(
-					`cd ${dest}; git init; git remote add origin ${this.repo.url}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
+					`cd ${dest}; git init; git remote add origin ${this.repo.ssh}; git fetch --depth 1 origin ${this.repo.ref}; git checkout FETCH_HEAD`
 				);
 			} else {
 				await exec(`git clone --depth 1 ${this.repo.ssh} ${dest}`);


### PR DESCRIPTION
Hello, in [private repository section of the doc](https://github.com/tiged/tiged#private-repositories) it's said
> Note: this clones over SSH, not HTTPS.

So I expected this behavior but this wasn't the case, this PR fix this ;)