### PR TITLE
fix: Delayed exit after successful clone

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -58,15 +58,17 @@ function exec(command, size = 500) {
 
 function fetch(url, dest, proxy) {
 	return new Promise((fulfil, reject) => {
-		let options = url;
-
+		const parsedUrl = URL.parse(url);
+		const options = {
+			hostname: parsedUrl.hostname,
+			port: parsedUrl.port,
+			path: parsedUrl.path,
+			headers: {
+				Connection: 'close'
+			}
+		};
 		if (proxy) {
-			const parsedUrl = URL.parse(url);
-			options = {
-				hostname: parsedUrl.host,
-				path: parsedUrl.path,
-				agent: new Agent(proxy)
-			};
+			options.agent = new Agent(proxy);
 		}
 
 		https


### PR DESCRIPTION

By adding the `Connection: close` header, the HTTP client cleans up the connection after the request is completed.

This drasticly improves the speed of tiged when run with `--disable-cache` or when there is no cached version available.
Fixes #79
