### PR TITLE
ci: Switch to Node.js v22

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           check-latest: true
           cache: 'npm'
 
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-latest]
 
     steps:
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, latest]
+        node-version: [18.x, 20.x, 22.x, latest]
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.0.0
 
+- ci: Switch to Node.js v22 ([#115](https://github.com/tiged/tiged/pull/115))
+
 - Fix husky and lint-staged ([#112](https://github.com/tiged/tiged/pull/112))
 
 - Fix typo ([#111](https://github.com/tiged/tiged/pull/111))


### PR DESCRIPTION
## **This PR**:

- [X] Switches to using Node.js v22 during CI workflows.