### PR TITLE
chore: ⚡️remove rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "fuzzysearch": "^1.0.3",
         "https-proxy-agent": "^7.0.6",
         "mri": "^1.2.0",
-        "rimraf": "^6.0.1",
         "tar": "^7.4.3",
         "tiny-glob": "^0.2.9"
       },
@@ -2409,29 +2408,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2443,30 +2419,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -2651,21 +2603,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/jackspeak": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -2973,15 +2910,6 @@
       "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.14",
@@ -3392,22 +3320,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -3681,25 +3593,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/rollup": {
       "version": "4.28.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint:fix": "eslint --color . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "npx rimraf dist",
+    "clean": "node scripts/deleteDist.js",
     "build": "npm run clean && tsup",
     "test": "vitest --typecheck",
     "test-types": "tsc -p tsconfig.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint:fix": "eslint --color . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "rimraf dist",
+    "clean": "npx rimraf dist",
     "build": "npm run clean && tsup",
     "test": "vitest --typecheck",
     "test-types": "tsc -p tsconfig.json --noEmit",
@@ -66,7 +66,6 @@
     "fuzzysearch": "^1.0.3",
     "https-proxy-agent": "^7.0.6",
     "mri": "^1.2.0",
-    "rimraf": "^6.0.1",
     "tar": "^7.4.3",
     "tiny-glob": "^0.2.9"
   },

--- a/scripts/deleteDist.js
+++ b/scripts/deleteDist.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+import {rmSync} from "node:fs";
+rmSync("./dist", { recursive: true, force: true });

--- a/scripts/deleteDist.js
+++ b/scripts/deleteDist.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-import {rmSync} from "node:fs";
-rmSync("./dist", { recursive: true, force: true });
+import { rmSync } from 'node:fs';
+rmSync('./dist', { recursive: true, force: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { execSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { rimraf } from 'rimraf';
 import { extract } from 'tar';
 import {
   TigedError,
@@ -471,7 +470,7 @@ class Tiged extends EventEmitter {
       if (await pathExists(filePath)) {
         const isDir = await isDirectory(filePath);
         if (isDir) {
-          await rimraf(filePath);
+          await fs.rm(filePath, { recursive: true, force: true });
           removedFiles.push(`${file}/`);
         } else {
           await fs.unlink(filePath);
@@ -508,7 +507,7 @@ class Tiged extends EventEmitter {
             message: `destination directory is not empty. Using options.force, continuing`,
           });
 
-          await rimraf(dir);
+          await fs.rm(dir, { recursive: true, force: true });
         } else {
           throw new TigedError(
             `destination directory is not empty, aborting. Use options.force to override`,
@@ -744,7 +743,7 @@ class Tiged extends EventEmitter {
       });
     }
     if (this.noCache) {
-      await rimraf(file);
+      await fs.rm(file);
     }
   }
 
@@ -785,7 +784,7 @@ class Tiged extends EventEmitter {
           );
         }),
       );
-      await rimraf(tempDir);
+      await fs.rm(tempDir, { recursive: true, force: true });
     } else {
       if (isWin) {
         await fs.mkdir(dest, { recursive: true });
@@ -800,7 +799,7 @@ class Tiged extends EventEmitter {
       } else {
         await exec(`git clone --depth 1 ${gitPath} ${dest}`);
       }
-      await rimraf(path.resolve(dest, '.git'));
+      await fs.rm(path.resolve(dest, '.git'), { recursive: true, force: true });
     }
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,6 @@ import { createRequire } from 'node:module';
 import type { constants } from 'node:os';
 import { homedir, tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { rimraf } from 'rimraf';
 
 const tmpDirName = 'tmp';
 
@@ -216,7 +215,7 @@ export async function fetch(url: string, dest: string, proxy?: string) {
 export async function stashFiles(dir: string, dest: string) {
   const tmpDir = path.join(dir, tmpDirName);
   try {
-    await rimraf(tmpDir);
+    await fs.rm(tmpDir, { recursive: true, force: true });
   } catch (e) {
     if (
       !(e instanceof Error && 'errno' in e && 'syscall' in e && 'code' in e)
@@ -264,7 +263,7 @@ export async function unstashFiles(dir: string, dest: string) {
       await fs.unlink(tmpFile);
     }
   }
-  await rimraf(tmpDir);
+  await fs.rm(tmpDir, { recursive: true, force: true });
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,6 @@ import * as child_process from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
-import { rimraf } from 'rimraf';
 import { tiged } from 'tiged';
 
 const exec = promisify(child_process.exec);
@@ -17,11 +16,11 @@ const convertSpecialCharsToHyphens = (str: string) =>
 
 describe(tiged, { timeout }, () => {
   beforeAll(async () => {
-    await rimraf('.tmp');
+    await fs.rm('.tmp', { recursive: true, force: true });
   });
 
   afterAll(async () => {
-    await rimraf('.tmp');
+    await fs.rm('.tmp', { recursive: true, force: true });
   });
 
   describe.sequential('github', () => {


### PR DESCRIPTION
using `fs.rm` instead.
For the `rimraf` in `npm run clean`. I just made an own node script deletes the `dist`.