### PR TITLE
Fix using commit hashes that doesn't have a ref

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -574,7 +574,17 @@ class Tiged extends EventEmitter {
         return refs?.find(ref => ref.type === 'HEAD')?.hash ?? '';
       }
 
-      return this._selectRef(refs, repo.ref);
+      const selectedRef = this._selectRef(refs, repo.ref);
+      if (selectedRef) {
+        return selectedRef
+      }
+
+      const isCommitHash = /^[0-9a-f]{40}$/.test(repo.ref);
+      if (!isCommitHash) {
+        return repo.ref
+      }
+      
+      return;
     } catch (err) {
       if (err instanceof TigedError && 'code' in err && 'message' in err) {
         this._warn(err);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -328,4 +328,16 @@ describe(tiged, { timeout }, () => {
       });
     });
   });
+
+  describe('commit hash', () => {
+    it('is able to clone non ref hash', async ({ task, expect }) => {
+      const sanitizedPath = convertSpecialCharsToHyphens(task.name);
+      await expect(
+        exec(
+          `${tigedPath} https://github.com/tiged/find-commit-hash-fix#83d5cae7fc5176f73486ffe82144044711930073 .tmp/test-repo-${sanitizedPath}`
+        )
+      ).resolves.not.toThrow();
+    });
+  });
+  
 });


### PR DESCRIPTION
### Summary
Allow tiged to accept commit hash that is not a ref (it referenced by a tag or a branch).