### PR TITLE
chore: replace `ansis` dependencies with `picocolors`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "2.12.7",
       "license": "MIT",
       "dependencies": {
-        "ansis": "^3.17.0",
         "enquirer": "^2.4.1",
         "fuzzysearch": "^1.0.3",
         "https-proxy-agent": "^7.0.6",
         "mri": "^1.2.0",
+        "picocolors": "^1.1.1",
         "tar": "^7.4.3",
         "tiny-glob": "^0.2.9"
       },
@@ -1589,15 +1589,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ansis": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
-      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/any-promise": {
@@ -3311,7 +3302,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
   },
   "homepage": "https://github.com/tiged/tiged#readme",
   "dependencies": {
-    "ansis": "^3.17.0",
     "enquirer": "^2.4.1",
     "fuzzysearch": "^1.0.3",
     "https-proxy-agent": "^7.0.6",
     "mri": "^1.2.0",
+    "picocolors": "^1.1.1",
     "tar": "^7.4.3",
     "tiny-glob": "^0.2.9"
   },

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 
-import { bold, cyan, magenta, red, underline } from 'ansis';
 import * as enquirer from 'enquirer';
 import fuzzysearch from 'fuzzysearch';
 import mri from 'mri';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import picocolors from 'picocolors';
 import type { Options } from 'tiged';
 import { tiged } from 'tiged';
 import glob from 'tiny-glob/sync.js';
 import { base, pathExists, tryRequire } from './utils.js';
+
+const { bold, cyan, magenta, red, underline } = picocolors;
 
 const args = mri<Options & { help?: string }>(process.argv.slice(2), {
   alias: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { bold, cyan, magenta, red } from 'ansis';
 import { execSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import picocolors from 'picocolors';
 import { extract } from 'tar';
 import {
   TigedError,
@@ -16,6 +16,8 @@ import {
   tryRequire,
   unstashFiles,
 } from './utils.js';
+
+const { bold, cyan, magenta, red } = picocolors;
 
 const validModes = new Set<ValidModes>(['tar', 'git']);
 


### PR DESCRIPTION
## **This PR**:

- [X] replaces `ansis` with `picocolors`.