### PR TITLE
feat: XDG-compliant cache directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import picocolors from 'picocolors';
 import { extract } from 'tar';
 import {
   TigedError,
-  base,
   exec,
   fetch,
+  getCacheDir,
   isDirectory,
   pathExists,
   stashFiles,
@@ -101,6 +101,14 @@ export interface Options {
    * @default undefined
    */
   'sub-directory'?: string;
+
+  /**
+   * Specifies a custom cache directory for storing downloaded tarballs.
+   * If not specified, uses XDG_CACHE_HOME/tiged or ~/.cache/tiged.
+   *
+   * @default undefined
+   */
+  cacheDir?: string;
 }
 
 // TODO: We might not need this one.
@@ -260,6 +268,11 @@ class Tiged extends EventEmitter {
   declare public subdir?: string;
 
   /**
+   * The cache directory for storing downloaded tarballs.
+   */
+  declare public cacheDir: string;
+
+  /**
    * Holds the parsed repository information.
    */
   declare public repo: Repo;
@@ -313,6 +326,7 @@ class Tiged extends EventEmitter {
     this.proxy = this._getHttpsProxy(); // TODO allow setting via --proxy
     this.subgroup = opts.subgroup;
     this.subdir = opts['sub-directory'];
+    this.cacheDir = getCacheDir(opts.cacheDir);
 
     this.repo = parse(src);
     if (this.subgroup) {
@@ -423,7 +437,7 @@ class Tiged extends EventEmitter {
 
     await this._checkDirIsEmpty(dest);
     const { repo } = this;
-    const dir = path.join(base, repo.site, repo.user, repo.name);
+    const dir = path.join(this.cacheDir, repo.site, repo.user, repo.name);
 
     if (this.mode === 'tar') {
       await this._cloneWithTar(dir, dest);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,31 @@ const getHomeOrTmp = () => homedir() || tmpdir();
 const homeOrTmp = /* @__PURE__ */ getHomeOrTmp();
 
 /**
+ * Gets the XDG-compliant cache directory.
+ * Respects $XDG_CACHE_HOME, falling back to ~/.cache
+ */
+function getXdgCacheDir(): string {
+  const xdgCache = process.env.XDG_CACHE_HOME;
+  if (xdgCache) {
+    return path.join(xdgCache, 'tiged');
+  }
+  return path.join(homeOrTmp, '.cache', 'tiged');
+}
+
+/**
+ * Gets the base cache directory for tiged.
+ * 
+ * @param customCacheDir - Optional custom cache directory override
+ * @returns The cache directory path
+ */
+export function getCacheDir(customCacheDir?: string): string {
+  if (customCacheDir) {
+    return customCacheDir;
+  }
+  return getXdgCacheDir();
+}
+
+/**
  * Represents the possible error codes for the Tiged utility.
  */
 export type TigedErrorCode =
@@ -312,4 +337,7 @@ export const isDirectory = async (filePath: string): Promise<boolean> => {
   }
 };
 
-export const base = /* @__PURE__ */ path.join(homeOrTmp, '.degit');
+/**
+ * @deprecated Use getCacheDir() instead. This is kept for backward compatibility.
+ */
+export const base = /* @__PURE__ */ getCacheDir();


### PR DESCRIPTION
Instead of hardcoded `.degit`/`.tiged` in home dir, use the [XDG base directory spec](https://specifications.freedesktop.org/basedir/latest/).

- Add `getCacheDir()` function that respects `XDG_CACHE_HOME`
- Default cache location changed from `~/.degit` to `~/.cache/tiged`
- Add `cacheDir` option to Options interface for custom cache paths
- Deprecate hardcoded `base` constant in favor of `getCacheDir()`