### PR TITLE
chore: add `allowScripts` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "allowScripts": {
+    "esbuild@0.27.4": true
   }
 }


### PR DESCRIPTION
## Summary

- Add **`allowScripts`** to **`package.json`** which is generated by running the [**`npm approve-scripts` CLI subcommand**](https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts) to approve which packages may execute scripts during **`npm install`**.
- Resolve #166.