### PR TITLE
ci: publish preview packages via `pkg-pr-new`

### DIFF
--- a/.github/workflows/release-commit.yml
+++ b/.github/workflows/release-commit.yml
@@ -1,0 +1,38 @@
+name: Release Commit
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release Commit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          cache: 'npm'
+          check-latest: true
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        id: publish
+        run: >
+          npm exec pkg-pr-new publish
+          .
+          -- --packageManager="npm,yarn,pnpm,bun" --commentWithDev --commentWithSha

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.3",
+        "pkg-pr-new": "^0.0.75",
         "prettier": "^3.8.1",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
@@ -3436,6 +3437,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.75.tgz",
+      "integrity": "sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
       }
     },
     "node_modules/pkg-types": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.3",
+    "pkg-pr-new": "^0.0.75",
     "prettier": "^3.8.1",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary

- Add a [**`pkg-pr-new`**](https://github.com/stackblitz-labs/pkg.pr.new) workflow that publishes preview builds per commit/PR, installable via **`npm install https://pkg.pr.new/tiged@{PR}`**.
- Add [**`pkg-pr-new`**](https://github.com/stackblitz-labs/pkg.pr.new) as a local dev dependency, as recommended in its documentation.
- Resolve #172.